### PR TITLE
Searching for paths using Breadth-First-Search(BFS)

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -264,6 +264,8 @@ class Architecture(Summarizable):
         max_node_depth: int | None = None,
         node_filter: Callable[[str], bool] | None = None,
         communication_filter: Callable[[str], bool] | None = None,
+        depth_first: bool = True,
+        first_only: bool = False
     ) -> list[PathStructValue]:
         for node_name in node_names:
             if node_name not in self.node_names:
@@ -294,7 +296,7 @@ class Architecture(Summarizable):
         path_searcher = NodePathSearcher(
             tuple(self._nodes), tuple(self._communications), node_filter, communication_filter)
         paths = [v.to_value() for v in
-                 path_searcher.search(*node_names, max_node_depth=max_node_depth)]
+                 path_searcher.search(*node_names, max_node_depth=max_node_depth, depth_first=depth_first, first_only=first_only)]
 
         # Print message after search
         msg = f'A search up to depth {max_node_depth} has been completed. '

--- a/src/caret_analyze/architecture/graph_search.py
+++ b/src/caret_analyze/architecture/graph_search.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict, UserList
+from collections import defaultdict, UserList, deque
 from collections.abc import Callable
 from copy import deepcopy
 from itertools import product
@@ -162,6 +162,39 @@ class GraphCore:
                 if edges_cache == []:
                     return
 
+    def _search_paths_width(
+        self,
+        u: int,
+        d: int,
+        edge: GraphEdgeCore | None,
+        visited: dict[tuple[int, int], bool],
+        path: GraphPathCore,
+        paths: list[GraphPathCore],
+        max_depth: int = 0
+    ) -> None:
+        queue = deque([(u, deepcopy(path), deepcopy(visited), 0)])
+
+        while queue:
+            current_node, current_path, current_visited, current_depth = queue.popleft()
+
+            if current_node == d and len(current_path) > 0:
+                paths.append(deepcopy(current_path))
+                return
+
+            if 0 < max_depth < current_depth:
+                continue
+
+            for edge in self._graph[current_node]:
+                next_node = edge.i_to
+                if current_visited[current_node, next_node] is False:
+                    next_path = deepcopy(current_path)
+                    next_path.append(edge)
+                    next_visited = deepcopy(current_visited)
+                    next_visited[current_node, next_node] = True
+                    queue.append(
+                        (next_node, next_path, next_visited, current_depth + 1)
+                    )
+
     def search_paths(
         self,
         start: int,
@@ -177,7 +210,8 @@ class GraphCore:
         paths: list[GraphPathCore] = []
 
         # self._search_paths_recursion(start, goal, None, visited, path, paths)
-        self._search_paths(start, goal, None, visited, path, paths, max_depth)
+        # self._search_paths(start, goal, None, visited, path, paths, max_depth)
+        self._search_paths_width(start, goal, None, visited, path, paths, max_depth)
 
         return paths
 


### PR DESCRIPTION
Depth-First-Search(DFS) consumes more than 64 GB of memory, preventing path exploration from completing.
For details, please refer to [tier4/caret #215](https://github.com/tier4/caret/issues/215).

Therefore, I implement Breadth-First-Search(BFS) and make it controllable with optional arguments.
The default behavior remains DFS, maintaining backward compatibility.
